### PR TITLE
Make test run in site-packages

### DIFF
--- a/dryft/sample/test.py
+++ b/dryft/sample/test.py
@@ -3,9 +3,10 @@ import pandas as pd
 from scipy.signal import butter, filtfilt
 import matplotlib.pyplot as plt
 import numpy as np
-
+from pathlib import Path
 # Read in data from force plate
-GRF = pd.read_csv('dryft\sample\custom_drift_S001runT25.csv', header = None)
+GRF = pd.read_csv(Path(__file__).parent /
+                  'custom_drift_S001runT25.csv', header=None)
 
 # Apply Butterworth Filter
 Fs = 300
@@ -13,11 +14,13 @@ Fc = 50
 Fn = (Fs / 2)
 n_pass = 2  # filtfilt is dual pass
 order = 2  # filtfilt doubles effective order (resulting order = 2*order)
-C = (2**(1/n_pass) - 1)**(1/(2*order))  # Correction factor per Research Methods in Biomechanics (2e) pg 288
+# Correction factor per Research Methods in Biomechanics (2e) pg 288
+C = (2**(1/n_pass) - 1)**(1/(2*order))
 Wn = (np.tan(np.pi*Fc/Fs))/C  # Apply correction to adjusted cutoff freq
 Fc_corrected = np.arctan(Wn)*Fs/np.pi  # Hz
-b,a = butter(order, Fc_corrected/Fn)
-GRF_filt = filtfilt(b, a, GRF, axis=0)  # filtfilt doubles order (2nd*2 = 4th order effect)
+b, a = butter(order, Fc_corrected/Fn)
+# filtfilt doubles order (2nd*2 = 4th order effect)
+GRF_filt = filtfilt(b, a, GRF, axis=0)
 
 # Identify where stance phase occurs (foot on ground)
 stance_begin_all, stance_end_all, good_stances = signal.splitsteps(vGRF=GRF_filt,
@@ -31,10 +34,12 @@ stance_end = stance_end_all[good_stances]
 # plot.stance(GRF_filt, stance_begin, stance_end)
 
 # Determine force signal at middle of aerial phase (feet not on ground)
-aerial_vals, aerial_loc = signal.aerialforce(GRF_filt, stance_begin_all, stance_end_all, good_stances)
+aerial_vals, aerial_loc = signal.aerialforce(
+    GRF_filt, stance_begin_all, stance_end_all, good_stances)
 
 # Plot all aerial phases to see what is being subtracted from signal in signal.detrend()
-plot.aerial(GRF_filt, aerial_vals, aerial_loc, stance_begin_all, stance_end_all, good_stances)
+plot.aerial(GRF_filt, aerial_vals, aerial_loc,
+            stance_begin_all, stance_end_all, good_stances)
 
 # Detrend signal
 force_fd = signal.detrend(GRF_filt, aerial_vals, aerial_loc)
@@ -49,7 +54,8 @@ stance_begin_all_d, stance_end_all_d, good_stances_d = signal.splitsteps(vGRF=fo
 stance_begin_d = stance_begin_all_d[good_stances_d]
 stance_end_d = stance_end_all_d[good_stances_d]
 
-aerial_vals_d, aerial_loc_d = signal.aerialforce(force_fd, stance_begin_all_d, stance_end_all_d, good_stances_d)
+aerial_vals_d, aerial_loc_d = signal.aerialforce(
+    force_fd, stance_begin_all_d, stance_end_all_d, good_stances_d)
 
 # Plot waveforms (original vs corrected)
 plt.detrendp, (plt1, plt2) = plt.subplots(2, 1, figsize=(15, 7))
@@ -63,7 +69,7 @@ plt1.plot(np.linspace(0, force_fd.shape[0] / Fs, force_fd.shape[0]),
           color='tab:blue',
           alpha=0.75,
           label='Corrected Signal')  # converted to sec
-plt1.grid(zorder =0)
+plt1.grid(zorder=0)
 plt1.legend(loc=2)
 plt1.set_xlabel('Seconds')
 plt1.set_ylabel('Force (N)')
@@ -76,16 +82,16 @@ plt.scatter(aerial_loc,
             aerial_vals,
             marker='o',
             color='tab:red',
-            label='Original Signal', zorder = 2)
+            label='Original Signal', zorder=2)
 plt.scatter(aerial_loc_d,
             aerial_vals_d,
             marker='o',
             color='tab:blue',
-            label='Corrected Signal', zorder = 2)
+            label='Corrected Signal', zorder=2)
 
 plt2.legend(loc=2)
 plt.tight_layout()
-plt2.grid(zorder = 0)
+plt2.grid(zorder=0)
 plt.show(block=True)
 
 print('dryft test complete')

--- a/setup.py
+++ b/setup.py
@@ -4,17 +4,18 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
-    name = "dryft",
-    version = "1.0.4",
-    packages = find_packages(),
-    install_requires = ['numpy','pandas>=0.24.0','matplotlib','scipy'],
-    author = "Ryan Alcantara",
-    description = "A package to process biomechanical running data",
+    name="dryft",
+    version="1.0.4",
+    packages=find_packages(),
+    install_requires=['numpy', 'pandas>=0.24.0', 'matplotlib', 'scipy'],
+    author="Ryan Alcantara",
+    description="A package to process biomechanical running data",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    author_email = "ryan.alcantara@colorado.edu",
-    license = "MIT",
-    url = "http://github.com/alcantarar/dryft",   # project home page, if any
+    author_email="ryan.alcantara@colorado.edu",
+    package_data={"dryft": ["sample/custom_drift_S001runT25.csv"]},
+    license="MIT",
+    url="http://github.com/alcantarar/dryft",   # project home page, if any
 
     # could also include long_description, download_url, classifiers, etc.
 )


### PR DESCRIPTION
I made `python -m dryft.sample.test` runnable after installation to site-packages.

I also noted now that my IDE autoformatted the code into pep8. That caused a lot of changes masking the relevant ones. Sorry.
Relevant are the creation of an  `__init__.py`, lines 6 - 9 in dryft/sample/test.py and line 16 in setup.py
